### PR TITLE
feat(scripts): update the helper scripts to validate if resource exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For a detailed walkthrough on Azure Managed Identities with Workload Identity Fe
 ## Pre-requisites
 
 - Resource group with Azure OpenAI
-- Azure OpeanAI deployments (depends the deployement you want to use): `gpt-35-turbo`, `gpt-4`
+- Azure OpeanAI deployments (depends the deployement you want to use): `gpt-35-turbo`, `gpt-4` -- a helper script can be found under `infra/pre-requisites.sh`
 
 ## Running the Application Locally
 

--- a/infra/azcli.sh
+++ b/infra/azcli.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 
-
 # Set variables
-RESOURCE_GROUP="rsg-bunnings-swiftsolve-01"
+RESOURCE_GROUP="rsg-swiftsolve-01"
 LOCATION="australiaeast"
 SERVICE_ACCOUNT_NAMESPACE="default"
 SERVICE_ACCOUNT_NAME="gradio-aks-sa"
-CLUSTER_NAME="aks-bunnings-swiftsolve-01"
+CLUSTER_NAME="aks-swiftsolve-01"
 ACR="amldsworkspaceacr"
 
 # Create AKS cluster

--- a/infra/azcli.sh
+++ b/infra/azcli.sh
@@ -6,21 +6,21 @@ LOCATION="australiaeast"
 SERVICE_ACCOUNT_NAMESPACE="default"
 SERVICE_ACCOUNT_NAME="gradio-aks-sa"
 CLUSTER_NAME="aks-swiftsolve-01"
-ACR="amldsworkspaceacr"
+USER_ASSIGNED_IDENTITY_NAME="gradioaksswiftsolveidentity"
+FEDERATED_IDENTITY_CREDENTIAL_NAME="gradioaksswiftsolveidentity-federated-credential"
 
 # Create AKS cluster
-az aks create -g "${RESOURCE_GROUP}" -n "${CLUSTER_NAME}" --node-count 1 --enable-oidc-issuer --enable-workload-identity --attach-acr "${ACR}" --enable-managed-identity || exit 1
+az aks show -g "${RESOURCE_GROUP}" -n "${CLUSTER_NAME}" || az aks create -g "${RESOURCE_GROUP}" -n "${CLUSTER_NAME}" --node-count 1 --enable-oidc-issuer --enable-workload-identity --enable-managed-identity || exit 1
 
 # Get OIDC issuer URL
 AKS_OIDC_ISSUER="$(az aks show -n "${CLUSTER_NAME}" -g "${RESOURCE_GROUP}" --query "oidcIssuerProfile.issuerUrl" -otsv)" || exit 1
 
 # Create user-assigned identity
-USER_ASSIGNED_IDENTITY_NAME="gradioaksidentity"
-az identity create --name "${USER_ASSIGNED_IDENTITY_NAME}" --resource-group "${RESOURCE_GROUP}" --location "${LOCATION}" || exit 1
+az identity show --name "${USER_ASSIGNED_IDENTITY_NAME}" --resource-group "${RESOURCE_GROUP}" || az identity create --name "${USER_ASSIGNED_IDENTITY_NAME}" --resource-group "${RESOURCE_GROUP}" --location "${LOCATION}" || exit 1
 
 # Assign role to user-assigned identity
 RESOURCE_ID="$(az group show -g "${RESOURCE_GROUP}" --query "id" -o tsv)" || exit 1
-az role assignment create --role "Cognitive Services User" --assignee "$(az identity show --resource-group "${RESOURCE_GROUP}" --name "${USER_ASSIGNED_IDENTITY_NAME}" --query 'clientId' -otsv)" --scope "${RESOURCE_ID}" || exit 1
+ az identity show --resource-group "${RESOURCE_GROUP}" --name "${USER_ASSIGNED_IDENTITY_NAME}" --query 'clientId' -otsv || az role assignment create --role "Cognitive Services User" --assignee "$(az identity show --resource-group "${RESOURCE_GROUP}" --name "${USER_ASSIGNED_IDENTITY_NAME}" --query 'clientId' -otsv)" --scope "${RESOURCE_ID}" || exit 1
 
 # Retrieve aks credentials
 az aks get-credentials -g "${RESOURCE_GROUP}" -n "${CLUSTER_NAME}" -a || exit 1
@@ -37,5 +37,4 @@ metadata:
 EOF
 
 # Federate the account and the managed identity
-FEDERATED_IDENTITY_CREDENTIAL_NAME="gradioaksidentity-federated-credential"
-az identity federated-credential create --name "${FEDERATED_IDENTITY_CREDENTIAL_NAME}" --identity-name "${USER_ASSIGNED_IDENTITY_NAME}" --resource-group "${RESOURCE_GROUP}" --issuer "${AKS_OIDC_ISSUER}" --subject "system:serviceaccount:${SERVICE_ACCOUNT_NAMESPACE}:${SERVICE_ACCOUNT_NAME}" || exit 1
+az identity federated-credential show  --name "${FEDERATED_IDENTITY_CREDENTIAL_NAME}" --identity-name "${USER_ASSIGNED_IDENTITY_NAME}" --resource-group "${RESOURCE_GROUP}" || az identity federated-credential create --name "${FEDERATED_IDENTITY_CREDENTIAL_NAME}" --identity-name "${USER_ASSIGNED_IDENTITY_NAME}" --resource-group "${RESOURCE_GROUP}" --issuer "${AKS_OIDC_ISSUER}" --subject "system:serviceaccount:${SERVICE_ACCOUNT_NAMESPACE}:${SERVICE_ACCOUNT_NAME}" || exit 1

--- a/infra/pre-requisites.sh
+++ b/infra/pre-requisites.sh
@@ -23,7 +23,7 @@ echo "Resource group validated."
 
 # Create openai workspace if it doesn't exist
 echo "Creating OpenAI workspace..."
-az cognitiveservices account show -n $OPENAI_NAME -g $RESOURCE_GROUP || az cognitiveservices account create --name $OPENAI_NAME --resource-group $RESOURCE_GROUP --location $LOCATION --kind OpenAI --sku s0 --yes || exit 1
+az cognitiveservices account show -n $OPENAI_NAME -g $RESOURCE_GROUP || az cognitiveservices account create --name $OPENAI_NAME --resource-group $RESOURCE_GROUP --location $LOCATION --kind OpenAI --sku s0 --custom-domain $OPENAI_NAME --yes || exit 1
 echo "OpenAI workspace created."
 
 # Create a deployment GPT_35_TURBO and GPT_4

--- a/infra/pre-requisites.sh
+++ b/infra/pre-requisites.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Set variables
+RESOURCE_GROUP="rsg-swiftsolve-01"
+LOCATION="australiaeast"
+OPENAI_NAME="aoai-swiftsolve-01"
+GPT_35_TURBO="gpt-35-turbo"
+GPT_4="gpt-4"
+
+PROJECT_NAME="akstest"
+END_DATE="20231115"
+TEAM_NAME="THE TEAM"
+
+# validate logged in into azure
+echo "Validating Azure login..."
+az account show || exit 1
+echo "Azure login validated."
+
+# Validate if resource group exists - otherwise create it with 3 tags (project, enddate, team) use variables
+echo "Validating resource group..."
+az group show -g "${RESOURCE_GROUP}" || az group create -g "${RESOURCE_GROUP}" -l "${LOCATION}" --tags project="${PROJECT_NAME}" enddate="${END_DATE}" team="${TEAM_NAME}" || exit 1
+echo "Resource group validated."
+
+# Create openai workspace if it doesn't exist
+echo "Creating OpenAI workspace..."
+az cognitiveservices account show -n $OPENAI_NAME -g $RESOURCE_GROUP || az cognitiveservices account create --name $OPENAI_NAME --resource-group $RESOURCE_GROUP --location $LOCATION --kind OpenAI --sku s0 --yes || exit 1
+echo "OpenAI workspace created."
+
+# Create a deployment GPT_35_TURBO and GPT_4
+echo "Creating OpenAI deployments..."
+# validate if deployment exits - otherwise create it
+az cognitiveservices account deployment show --deployment-name $GPT_35_TURBO --name $OPENAI_NAME --resource-group $RESOURCE_GROUP || az cognitiveservices account deployment create --deployment-name $GPT_35_TURBO --model-format OpenAI --model-name $GPT_35_TURBO --model-version "0613" --name $OPENAI_NAME --resource-group $RESOURCE_GROUP || exit 1
+az cognitiveservices account deployment show --deployment-name $GPT_4 --name $OPENAI_NAME --resource-group $RESOURCE_GROUP || az cognitiveservices account deployment create --deployment-name $GPT_4 --model-format OpenAI --model-name $GPT_4 --model-version "0613" --name $OPENAI_NAME --resource-group $RESOURCE_GROUP || exit 1
+echo "OpenAI deployments created."

--- a/release/manifest-gpt4.yaml
+++ b/release/manifest-gpt4.yaml
@@ -24,7 +24,7 @@ spec:
             - name: OPENAI_API_TYPE
               value: "azure_ad"
             - name: OPENAI_API_BASE
-              value: "https://llm-experiment.openai.azure.com/"
+              value: "https://aoai-swiftsolve-01.openai.azure.com/"
             - name: OPENAI_API_VERSION
               value: "2023-08-01-preview"
             - name: TEMPERATURE

--- a/release/manifest.yaml
+++ b/release/manifest.yaml
@@ -24,7 +24,7 @@ spec:
             - name: OPENAI_API_TYPE
               value: "azure_ad"
             - name: OPENAI_API_BASE
-              value: "https://llm-experiment.openai.azure.com/"
+              value: "https://aoai-swiftsolve-01.openai.azure.com/"
             - name: OPENAI_API_VERSION
               value: "2023-08-01-preview"
             - name: TEMPERATURE


### PR DESCRIPTION
This pull request includes changes to improve the authentication and functionality of the codebase for pulling images from a private registry, updating the OpenAI API endpoint URL, and allowing for the use of a custom domain for OpenAI workspace.

Main changes:

* <a href="diffhunk://#diff-8cf05737c3e3d184a93dcd75715c63105a73fa12a5455b82c21ea81f2e639a37L9-R23">`infra/azcli.sh`</a>: The changes in `infra/azcli.sh` allow for the use of a user-assigned identity instead of an ACR for authentication when pulling images from a private registry. <a href="diffhunk://#diff-8cf05737c3e3d184a93dcd75715c63105a73fa12a5455b82c21ea81f2e639a37L9-R23">[1]</a> <a href="diffhunk://#diff-8cf05737c3e3d184a93dcd75715c63105a73fa12a5455b82c21ea81f2e639a37L40-R40">[2]</a>
* <a href="diffhunk://#diff-c5da43c0f87a64547675fd81daab2ca0d3d0e4438d720a72d851c40ad10110d4L27-R27">`release/manifest-gpt4.yaml`</a>: Updated the OpenAI API endpoint URL in `release/manifest-gpt4.yaml`.
* <a href="diffhunk://#diff-0915d76c2343ee1b2ca0f5a603457fcd69d6cc353324c50e1b8716199afb94caL26-R26">`infra/pre-requisites.sh`</a>: Updated `az cognitiveservices account create` command in `infra/pre-requisites.sh` to allow for use of custom domain for OpenAI workspace.
* <a href="diffhunk://#diff-47bd4bfaf40ce661883b3397948b9fddcd1fd4b0c01305a49749ff60db161f6aL27-R27">`release/manifest.yaml`</a>: Updated `OPENAI_API_BASE` value in `release/manifest.yaml` to point to a new URL for the OpenAI API.